### PR TITLE
implemented better type safety for adding future prompts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,7 @@ const promts: PromptObject[] = [
 (async () => {
   console.log(chalk.red("Welcome to the create-t3-app !"));
 
-  const { name, packages } = await prompts(promts);
+  const { name, packages } = await prompts(promts) as { name: string, packages: string[]};
 
   // TODO: It should probably be createProject's responsiblity to interpret the `packages` array
   const usingPrisma = packages.some((p: string) => p === "prisma");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import chalk from "chalk";
 import prompts, { type PromptObject } from "prompts";
+import { logger } from "./helpers/logger";
 
 import createProject from "./helpers/create";
 
@@ -14,7 +14,7 @@ const promts: PromptObject[] = [
     message: "What will your project be called?",
     format: (name: string) => {
       if (name === "") {
-        console.log(chalk.yellow(`Using default name: ${DEFAULT_PROJECT_NAME}`));
+        logger.warn(`Using default name: ${DEFAULT_PROJECT_NAME}`);
         return DEFAULT_PROJECT_NAME;
       }
       return name.trim();
@@ -37,9 +37,9 @@ const promts: PromptObject[] = [
     ],
     format: (language: string) => {
       if (language === "javascript") {
-        console.log(chalk.red("Wrong answer, using TypeScript instead..."));
+        logger.error("Wrong answer, using TypeScript instead...");
       } else {
-        console.log(chalk.green("Good choice! Using TypeScript!"));
+        logger.success("Good choice! Using TypeScript!");
       }
       return;
     }
@@ -64,7 +64,7 @@ const promts: PromptObject[] = [
 ];
 
 (async () => {
-  console.log(chalk.red("Welcome to the create-t3-app !"));
+  logger.error("Welcome to the create-t3-app !");
 
   const { name, packages } = await prompts(promts) as { name: string, packages: string[]};
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ const promts: PromptObject[] = [
         return DEFAULT_PROJECT_NAME;
       }
       return name.trim();
-     },
+    },
   },
   {
     name: "language",
@@ -42,7 +42,7 @@ const promts: PromptObject[] = [
         logger.success("Good choice! Using TypeScript!");
       }
       return;
-    }
+    },
   },
   /*{
     name: "packages",
@@ -63,24 +63,32 @@ const promts: PromptObject[] = [
   }*/
   {
     name: "usePrisma",
-    type: "confirm",
+    type: "toggle",
     message: "Would you like to use Prisma?",
     initial: true,
+    active: "Yes",
+    inactive: "No",
   },
   {
     name: "useNextAuth",
     // only show this prompt if usePrisma is true
-    type: (prev) => prev ? "confirm" : null,
+    type: (prev) => (prev ? "toggle" : null),
     message: "Would you like to use Next Auth?",
     initial: true,
-  }
+    active: "Yes",
+    inactive: "No",
+  },
 ];
 
 (async () => {
   logger.error("Welcome to the create-t3-app !");
 
   // FIXME: Look into if the type can be inferred
-  const { name, usePrisma, useNextAuth } = await prompts(promts) as { name: string, usePrisma: boolean, useNextAuth: boolean | undefined };
+  const { name, usePrisma, useNextAuth } = (await prompts(promts)) as {
+    name: string;
+    usePrisma: boolean;
+    useNextAuth: boolean | undefined;
+  };
   const useNextAuthBool = !!useNextAuth;
 
   await createProject(name, usePrisma, useNextAuthBool);

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,7 @@ const promts: PromptObject[] = [
 
   const { name, packages } = await prompts(promts);
 
+  // TODO: It should probably be createProject's responsiblity to interpret the `packages` array
   const usingPrisma = packages.some((p: string) => p === "prisma");
   const usingNextAuth = packages.some((p: string) => p === "next-auth");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,75 +1,75 @@
 #!/usr/bin/env node
 
 import chalk from "chalk";
-import prompts from "prompts";
+import prompts, { type PromptObject } from "prompts";
 
 import createProject from "./helpers/create";
 
-const promptOne = {
-  type: "text",
-  name: "name",
-  message: "What will your project be called?",
-};
+const DEFAULT_PROJECT_NAME = "my-t3-app";
 
-const promptTwo = {
-  type: "select",
-  name: "language",
-  message: "Will you be using JavaScript or TypeScript?",
-  choices: [
-    {
-      title: "JavaScript",
-      value: "javascript",
-    },
-    {
-      title: "TypeScript",
-      value: "typescript",
-    },
-  ],
-  initial: 0,
-};
-
-const promptThree = {
-  type: "toggle",
-  name: "usingPrisma",
-  message: "Would you like to use Prisma?",
-  initial: true,
-  active: "Yes",
-  inactive: "No",
-};
-
-const promptFour = {
-  type: "toggle",
-  name: "useNextAuth",
-  message: "Would you like to use next-auth?",
-  initial: true,
-  active: "Yes",
-  inactive: "No",
-};
+const promts: PromptObject[] = [
+  {
+    name: "name",
+    type: "text",
+    message: "What will your project be called?",
+    format: (name: string) => {
+      if (name === "") {
+        console.log(chalk.yellow(`Using default name: ${DEFAULT_PROJECT_NAME}`));
+        return DEFAULT_PROJECT_NAME;
+      }
+      return name.trim();
+     },
+  },
+  {
+    name: "language",
+    type: "select",
+    message: "Will you be using JavaScript or TypeScript?",
+    instructions: false,
+    choices: [
+      {
+        title: "JavaScript",
+        value: "javascript",
+      },
+      {
+        title: "TypeScript",
+        value: "typescript",
+      },
+    ],
+    format: (language: string) => {
+      if (language === "javascript") {
+        console.log(chalk.red("Wrong answer, using TypeScript instead..."));
+      } else {
+        console.log(chalk.green("Good choice! Using TypeScript!"));
+      }
+      return "typescript";
+    }
+  },
+  {
+    name: "packages",
+    type: "multiselect",
+    message: "Which packages will you be using?",
+    hint: "- Space to select, Return to submit",
+    instructions: false,
+    choices: [
+      {
+        title: "Next Auth",
+        value: "next-auth",
+      },
+      {
+        title: "Prisma",
+        value: "prisma",
+      },
+    ]
+  }
+];
 
 (async () => {
   console.log(chalk.red("Welcome to the create-t3-app !"));
 
-  const { name }: { name: string } = await prompts(promptOne as any);
-  const { language }: { language: string } = await prompts(promptTwo as any);
+  const { name, packages } = await prompts(promts);
 
-  if (language === "javascript") {
-    console.log(
-      `\n Wrong answer... Using ${chalk.blue("TypeScript")} instead. \n\n`
-    );
-  } else {
-    console.log(`\n Good choice! Using ${chalk.blue(language)} \n\n`);
-  }
-
-  const { usingPrisma }: { usingPrisma: boolean } = await prompts(
-    promptThree as any
-  );
-
-  let usingNextAuth = false;
-
-  if (usingPrisma) {
-    const { useNextAuth } = await prompts(promptFour as any);
-    usingNextAuth = useNextAuth;
-  }
+  const usingPrisma = packages.some((p: string) => p === "prisma");
+  const usingNextAuth = packages.some((p: string) => p === "next-auth");
 
   await createProject(name, usingPrisma, usingNextAuth);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,8 @@ const promts: PromptObject[] = [
   },
   {
     name: "useNextAuth",
-    type: "confirm",
+    // only show this prompt if usePrisma is true
+    type: (prev) => prev ? "confirm" : null,
     message: "Would you like to use Next Auth?",
     initial: true,
   }
@@ -79,9 +80,10 @@ const promts: PromptObject[] = [
   logger.error("Welcome to the create-t3-app !");
 
   // FIXME: Look into if the type can be inferred
-  const { name, usePrisma, useNextAuth } = await prompts(promts) as { name: string, usePrisma: boolean, useNextAuth: boolean };
+  const { name, usePrisma, useNextAuth } = await prompts(promts) as { name: string, usePrisma: boolean, useNextAuth: boolean | undefined };
+  const useNextAuthBool = !!useNextAuth;
 
-  await createProject(name, usePrisma, useNextAuth);
+  await createProject(name, usePrisma, useNextAuthBool);
 
   process.exit(0);
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ const promts: PromptObject[] = [
       return;
     }
   },
-  {
+  /*{
     name: "packages",
     type: "multiselect",
     message: "Which packages will you be using?",
@@ -60,19 +60,28 @@ const promts: PromptObject[] = [
         value: "prisma",
       },
     ]
+  }*/
+  {
+    name: "usePrisma",
+    type: "confirm",
+    message: "Would you like to use Prisma?",
+    initial: true,
+  },
+  {
+    name: "useNextAuth",
+    type: "confirm",
+    message: "Would you like to use Next Auth?",
+    initial: true,
   }
 ];
 
 (async () => {
   logger.error("Welcome to the create-t3-app !");
 
-  const { name, packages } = await prompts(promts) as { name: string, packages: string[]};
+  // FIXME: Look into if the type can be inferred
+  const { name, usePrisma, useNextAuth } = await prompts(promts) as { name: string, usePrisma: boolean, useNextAuth: boolean };
 
-  // TODO: It should probably be createProject's responsiblity to interpret the `packages` array
-  const usingPrisma = packages.some((p: string) => p === "prisma");
-  const usingNextAuth = packages.some((p: string) => p === "next-auth");
-
-  await createProject(name, usingPrisma, usingNextAuth);
+  await createProject(name, usePrisma, useNextAuth);
 
   process.exit(0);
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ const promts: PromptObject[] = [
       } else {
         console.log(chalk.green("Good choice! Using TypeScript!"));
       }
-      return "typescript";
+      return;
     }
   },
   {


### PR DESCRIPTION
Put all the prompts into an array with some type safety so that future prompts can be added and get some warnings.

The packages are now enables as a multi-select so adding more packages is easier and doesn't require a new prompt to be added.

Also put in some response messages such as when leaving name blank (Closing #11 in the process). See a demo [here (CleanShot link)](https://cleanshot-cloud-fra.accelerator.net/media/38032/Ze78t4RhWyHtcN6249n1JfUB211oD9zaQotGhnWQ.mp4).

**There is a limitation however. If selecting Next-Auth, but not Prisma, it will go ahead and create a project with both of them due to there only being one Next-Auth template available. I can look into perhaps making it so that every individual package is installed separately, and configs copied over accordingly, so that there won't have to be a template-folder for each combination.**