### PR TITLE
Add inferQueryResponse helper for tRPC

### DIFF
--- a/template/addons/trpc/api-handler.ts
+++ b/template/addons/trpc/api-handler.ts
@@ -1,6 +1,7 @@
 // src/pages/api/trpc/[trpc].ts
+import { inferProcedureOutput } from "@trpc/server";
 import { createNextApiHandler } from "@trpc/server/adapters/next";
-import { appRouter } from "../../../server/router";
+import { AppRouter, appRouter } from "../../../server/router";
 import { createContext } from "../../../server/router/context";
 
 // export API handler
@@ -8,3 +9,7 @@ export default createNextApiHandler({
   router: appRouter,
   createContext: createContext,
 });
+
+export type inferQueryResponse<
+  TRouteKey extends keyof AppRouter["_def"]["queries"]
+> = inferProcedureOutput<AppRouter["_def"]["queries"][TRouteKey]>;

--- a/template/addons/trpc/api-handler.ts
+++ b/template/addons/trpc/api-handler.ts
@@ -1,7 +1,6 @@
 // src/pages/api/trpc/[trpc].ts
-import { inferProcedureOutput } from "@trpc/server";
 import { createNextApiHandler } from "@trpc/server/adapters/next";
-import { AppRouter, appRouter } from "../../../server/router";
+import { appRouter } from "../../../server/router";
 import { createContext } from "../../../server/router/context";
 
 // export API handler
@@ -9,7 +8,3 @@ export default createNextApiHandler({
   router: appRouter,
   createContext: createContext,
 });
-
-export type inferQueryResponse<
-  TRouteKey extends keyof AppRouter["_def"]["queries"]
-> = inferProcedureOutput<AppRouter["_def"]["queries"][TRouteKey]>;

--- a/template/addons/trpc/utils.ts
+++ b/template/addons/trpc/utils.ts
@@ -3,3 +3,8 @@ import type { AppRouter } from "../server/router";
 import { createReactQueryHooks } from "@trpc/react";
 
 export const trpc = createReactQueryHooks<AppRouter>();
+
+/**
+ * Check out tRPC docs for Inference Helpers
+ * https://trpc.io/docs/infer-types#inference-helpers
+ */


### PR DESCRIPTION
Added a helper to infer types from queries in tRPC. It is a really important one that always needs to be googled because the syntax is really difficult. I believe it is really helpful to have this in the template.

Example:
Definition: https://github.com/TheoBr/roundest-mon/blob/e2834b689941df2c61b5acb9816f675437c92df9/src/pages/api/trpc/%5Btrpc%5D.ts#L11
Implementation: https://github.com/TheoBr/roundest-mon/blob/827d89463e1fc6edb7bbb5eb814fde67f6c36381/src/pages/index.tsx#L88