### PR TITLE
add postinstall script to package.json

### DIFF
--- a/src/installers/prisma.ts
+++ b/src/installers/prisma.ts
@@ -9,20 +9,18 @@ export const prismaInstaller: Installer = async (
   packageManager,
   packages
 ) => {
-  await Promise.all([
-    installPkgs({
-      packageManager,
-      projectDir,
-      packages: ["prisma"],
-      devMode: true,
-    }),
-    installPkgs({
-      packageManager,
-      projectDir,
-      packages: ["@prisma/client"],
-      devMode: false,
-    }),
-  ]);
+  await installPkgs({
+    packageManager,
+    projectDir,
+    packages: ["prisma"],
+    devMode: true,
+  });
+  await installPkgs({
+    packageManager,
+    projectDir,
+    packages: ["@prisma/client"],
+    devMode: false,
+  });
 
   const prismaAssetDir = path.join(
     __dirname,
@@ -42,10 +40,18 @@ export const prismaInstaller: Installer = async (
   const sampleApiRouteSrc = path.join(prismaAssetDir, "sample-api.ts");
   const sampleApiRouteDest = path.join(projectDir, "src/pages/api/examples.ts");
 
+  // add postinstall script to package.json
+  const packageJsonPath = path.join(projectDir, "package.json");
+  const packageJsonContent = await fs.readJSON(packageJsonPath);
+  packageJsonContent.scripts.postinstall = "prisma generate";
+
   await Promise.all([
     fs.copy(schemaSrc, schemaDest),
     fs.copy(clientSrc, clientDest),
     fs.copy(sampleApiRouteSrc, sampleApiRouteDest),
+    fs.writeJSON(packageJsonPath, packageJsonContent, {
+      spaces: 2,
+    }),
   ]);
 
   const generateClientCmd =


### PR DESCRIPTION
closing #24 and #21

- [x] added step to write a postinstall command to the package.json in the prisma installer
- [x] separated the installations of prisma and @prisma/client since doing these async caused some issues