### PR TITLE
Feat: windows build support, more readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,6 @@ yarn dev
 ```
 ## Dev
 
-To start the package locally on mac/linux
-```bash
-npm start
-```
-
-To start the package on windows:
-```bash
-npm start-w
-```
-
 To install dependencies
 ```bash
 pnpm install
@@ -44,6 +34,16 @@ pnpm install
 If you don't have pnpm you can install it with npm
 ```bash
 npm install -g pnpm
+```
+
+To start the package locally on mac/linux
+```bash
+npm start
+```
+
+To start the package on windows:
+```bash
+npm start-w
 ```
 
 ## Stack

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ yarn create t3-app
 # or
 pnpm create t3-app@latest
 ```
+To start your app 
+```bash
+yarn
+yarn dev
+```
+
+To install dependencies
+```bash
+pnpm install
+```
+
+If you don't have pnpm you can install it with npm
+```bash
+npm install -g pnpm
+```
 
 ## Stack
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,22 @@ yarn create t3-app
 # or
 pnpm create t3-app@latest
 ```
+
 To start your app 
 ```bash
 yarn
 yarn dev
+```
+## Dev
+
+To start the package locally on mac/linux
+```bash
+npm start
+```
+
+To start the package on windows:
+```bash
+npm start-w
 ```
 
 To install dependencies

--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@ yarn create t3-app
 pnpm create t3-app@latest
 ```
 
-To start your app 
-```bash
-yarn
-yarn dev
-```
 ## Dev
 
 To install dependencies
@@ -38,12 +33,12 @@ npm install -g pnpm
 
 To start the package locally on mac/linux
 ```bash
-npm start
+pnpm start
 ```
 
 To start the package on windows:
 ```bash
-npm start-w
+pnpm start-w
 ```
 
 ## Stack

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "build": "rm -rf dist && tsc && chmod +x dist/index.js",
-    "start": "npm run build && node dist/index.js"
+    "start": "npm run build && node dist/index.js",
+    "build-w": "rd /s dist && tsc && attrib +x dist/index.js",
+    "start-w": "npm run build-w && node dist/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I added support for windows by adding another script in package.json, this error popped up when trying to build:

![image](https://user-images.githubusercontent.com/80591403/175034034-4913623f-1d9b-444e-baa9-564fc9c36edd.png)

I added some instructions in the readme so it's easier for new people to start contributing.