### PR TITLE
Fix a small linting issue and cleanup extraneous comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "husky": "^8.0.1",
     "lint-staged": "^13.0.2",
     "prettier": "^2.7.1",
+    "type-fest": "^2.14.0",
     "typescript": "^4.6.4"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ specifiers:
   lint-staged: ^13.0.2
   prettier: ^2.7.1
   prompts: ^2.4.2
+  type-fest: ^2.14.0
   typescript: ^4.6.4
 
 dependencies:
@@ -42,6 +43,7 @@ devDependencies:
   husky: 8.0.1
   lint-staged: 13.0.2
   prettier: 2.7.1
+  type-fest: 2.14.0
   typescript: 4.6.4
 
 packages:
@@ -3961,6 +3963,11 @@ packages:
   /type-fest/0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+    dev: true
+
+  /type-fest/2.14.0:
+    resolution: {integrity: sha512-hQnTQkFjL5ik6HF2fTAM8ycbr94UbQXK364wF930VHb0dfBJ5JBP8qwrR8TaK9zwUEk7meruo2JAUDMwvuxd/w==}
+    engines: {node: '>=12.20'}
     dev: true
 
   /typescript/4.6.4:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import type { PackageJson } from "type-fest";
 import path from "path";
 import fs from "fs-extra";
 import prompts, { type PromptObject } from "prompts";
@@ -116,9 +117,10 @@ const main = async () => {
 
   logNextSteps(name, packages);
 
-  //TODO: Review lint error here and correct
-  const pkgJson = await fs.readJSON(path.join(projectDir, "package.json")); // eslint-disable-line
-  pkgJson.name = name; // eslint-disable-line
+  const pkgJson = (await fs.readJSON(
+    path.join(projectDir, "package.json"),
+  )) as PackageJson;
+  pkgJson.name = name;
   await fs.writeJSON(path.join(projectDir, "package.json"), pkgJson, {
     spaces: 2,
   });

--- a/src/installers/prisma.ts
+++ b/src/installers/prisma.ts
@@ -1,8 +1,9 @@
+import type { Installer } from "./index";
+import type { PackageJson } from "type-fest";
 import path from "path";
 import fs from "fs-extra";
 import { execa } from "../helpers/execa";
 import { installPkgs } from "../helpers/get-pkg-manager";
-import { type Installer } from "./index";
 
 export const prismaInstaller: Installer = async (
   projectDir,
@@ -43,9 +44,8 @@ export const prismaInstaller: Installer = async (
   // add postinstall script to package.json
   const packageJsonPath = path.join(projectDir, "package.json");
 
-  //TODO: Review lint error here and correct
-  const packageJsonContent = fs.readJSONSync(packageJsonPath); // eslint-disable-line
-  packageJsonContent.scripts.postinstall = "prisma generate"; // eslint-disable-line
+  const packageJsonContent = fs.readJSONSync(packageJsonPath) as PackageJson;
+  packageJsonContent.scripts!.postinstall = "prisma generate"; //eslint-disable-line @typescript-eslint/no-non-null-assertion
 
   await Promise.all([
     fs.copy(schemaSrc, schemaDest),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "outDir": "./dist",
     "declaration": true,
     "declarationMap": true,
-    // "emitDeclarationOnly": true, //TODO: Turn on after transitioning build tool to tsup
     "sourceMap": true,
     "removeComments": true,
 


### PR DESCRIPTION
As per the title, added 'type-fest' as a dev dependency to provide types for package.json (which was previously throwing a linting error).

Removed extra comments from my previous PR