### PR TITLE
feat: add path alias

### DIFF
--- a/template/addons/next-auth/api-handler-prisma.ts
+++ b/template/addons/next-auth/api-handler-prisma.ts
@@ -3,7 +3,7 @@ import GithubProvider from "next-auth/providers/github";
 
 // Prisma adapter for NextAuth, optional and can be removed
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
-import { prisma } from "../../../server/db/client";
+import { prisma } from "~/server/db/client";
 
 export default NextAuth({
   // Configure one or more authentication providers

--- a/template/addons/prisma/sample-api.ts
+++ b/template/addons/prisma/sample-api.ts
@@ -1,6 +1,6 @@
 // src/pages/api/examples.ts
 import type { NextApiRequest, NextApiResponse } from "next";
-import { prisma } from "../../server/db/client";
+import { prisma } from "~/server/db/client";
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const examples = await prisma.example.findMany();

--- a/template/addons/trpc/api-handler.ts
+++ b/template/addons/trpc/api-handler.ts
@@ -1,7 +1,7 @@
 // src/pages/api/trpc/[trpc].ts
 import { createNextApiHandler } from "@trpc/server/adapters/next";
-import { appRouter } from "../../../server/router";
-import { createContext } from "../../../server/router/context";
+import { appRouter } from "~/server/router";
+import { createContext } from "~/server/router/context";
 
 // export API handler
 export default createNextApiHandler({

--- a/template/addons/trpc/example-prisma-router.ts
+++ b/template/addons/trpc/example-prisma-router.ts
@@ -1,4 +1,4 @@
-import { createRouter } from "./context";
+import { createRouter } from "~/context";
 import { z } from "zod";
 
 export const exampleRouter = createRouter()

--- a/template/addons/trpc/example-router.ts
+++ b/template/addons/trpc/example-router.ts
@@ -1,4 +1,4 @@
-import { createRouter } from "./context";
+import { createRouter } from "~/context";
 import { z } from "zod";
 
 export const exampleRouter = createRouter().query("hello", {

--- a/template/addons/trpc/index-router.ts
+++ b/template/addons/trpc/index-router.ts
@@ -1,8 +1,8 @@
 // src/server/router/index.ts
-import { createRouter } from "./context";
+import { createRouter } from "~/context";
 import superjson from "superjson";
 
-import { exampleRouter } from "./example";
+import { exampleRouter } from "~/example";
 
 export const appRouter = createRouter()
   .transformer(superjson)

--- a/template/addons/trpc/prisma-context.ts
+++ b/template/addons/trpc/prisma-context.ts
@@ -1,7 +1,7 @@
 // src/server/router/context.ts
 import * as trpc from "@trpc/server";
 import * as trpcNext from "@trpc/server/adapters/next";
-import { prisma } from "../db/client";
+import { prisma } from "~/db/client";
 
 export const createContext = ({
   req,

--- a/template/addons/trpc/utils.ts
+++ b/template/addons/trpc/utils.ts
@@ -1,5 +1,5 @@
 // src/utils/trpc.ts
-import type { AppRouter } from "../server/router";
+import type { AppRouter } from "~/server/router";
 import { createReactQueryHooks } from "@trpc/react";
 
 export const trpc = createReactQueryHooks<AppRouter>();

--- a/template/base/src/pages/_app.tsx
+++ b/template/base/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import "../styles/globals.css";
+import "~/styles/globals.css";
 import type { AppProps } from "next/app";
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/template/base/tsconfig.json
+++ b/template/base/tsconfig.json
@@ -14,7 +14,11 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./src/*"]
+    }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/template/page-studs/_app/with-auth-trpc.tsx
+++ b/template/page-studs/_app/with-auth-trpc.tsx
@@ -1,10 +1,10 @@
 // src/pages/_app.tsx
 import { withTRPC } from "@trpc/next";
-import type { AppRouter } from "../server/router";
+import type { AppRouter } from "~/server/router";
 import type { AppType } from "next/dist/shared/lib/utils";
 import superjson from "superjson";
 import { SessionProvider } from "next-auth/react";
-import "../styles/globals.css";
+import "~/styles/globals.css";
 
 const MyApp: AppType = ({
   Component,

--- a/template/page-studs/_app/with-auth.tsx
+++ b/template/page-studs/_app/with-auth.tsx
@@ -1,4 +1,4 @@
-import "../styles/globals.css";
+import "~/styles/globals.css";
 import type { AppProps } from "next/app";
 import { SessionProvider } from "next-auth/react";
 

--- a/template/page-studs/_app/with-trpc.tsx
+++ b/template/page-studs/_app/with-trpc.tsx
@@ -1,9 +1,9 @@
 // src/pages/_app.tsx
 import { withTRPC } from "@trpc/next";
-import type { AppRouter } from "../server/router";
+import type { AppRouter } from "~/server/router";
 import type { AppType } from "next/dist/shared/lib/utils";
 import superjson from "superjson";
-import "../styles/globals.css";
+import "~/styles/globals.css";
 
 const MyApp: AppType = ({ Component, pageProps }) => {
   return <Component {...pageProps} />;

--- a/template/page-studs/index/with-trpc-tw.tsx
+++ b/template/page-studs/index/with-trpc-tw.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import Head from "next/head";
-import { trpc } from "../utils/trpc";
+import { trpc } from "~/utils/trpc";
 
 const Home: NextPage = () => {
   const hello = trpc.useQuery(["example.hello", { text: "from tRPC" }]);

--- a/template/page-studs/index/with-trpc.tsx
+++ b/template/page-studs/index/with-trpc.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 import Head from "next/head";
-import { trpc } from "../utils/trpc";
+import { trpc } from "~/utils/trpc";
 
 const Home: NextPage = () => {
   const { data, isLoading } = trpc.useQuery([


### PR DESCRIPTION
This PR adds path aliases for better readability when importing modules.

To import a module it needs to be in the `src` directory.
Then, to import a component use the syntax below:
`import Button from '~/components/Button'`

I've replaced the current imports to use the alias.

Next.js docs: https://nextjs.org/docs/advanced-features/module-path-aliases