### PR TITLE
bug-fix: Resolve pkg root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # create-t3-app
 
+## 4.2.9
+
+- fix resolved path to package root
+
 ## 4.2.8
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-t3-app",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "Create web application with the t3 stack",
   "author": "Shoubhit Dash <shoubhit2005@gmail.com>",
   "license": "MIT",

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,8 +1,13 @@
 import path from "path";
+import { fileURLToPath } from "url";
 
 // With the move to TSUP as a build tool, this keeps path routes in other files (installers, loaders, etc) in check more easily.
 // Path is in relation to a single index.js file inside ./dist
-export const PKG_ROOT = path.dirname("../");
+const __filename = fileURLToPath(import.meta.url);
+const distPath = path.dirname(__filename);
+export const PKG_ROOT = path.join(distPath, "../");
+
+//export const PKG_ROOT = path.dirname(require.main.filename);
 
 export const TITLE_TEXT = `Welcome to the create-t3-app !`;
 export const DEFAULT_APP_NAME = "my-t3-app";


### PR DESCRIPTION
Closes #65 

Investigated lots of options using `process.mainModule`, `require.main` etc but these options are not compatible with ESM. The solution I [found](https://bobbyhadz.com/blog/javascript-dirname-is-not-defined-in-es-module-scope), which was also proposed by @devkevbot in [#65 (comment)](https://github.com/nexxeln/create-t3-app/issues/65#issuecomment-1168430972) was to use `import.meta.url` instead.

```ts
import path from "path";
import { fileURLToPath } from "url";

const __filename = fileURLToPath(import.meta.url); // path/to/create-t3-app/dist/index.js
const distPath = path.dirname(__filename); // path/to/create-t3-app/dist
export const PKG_ROOT = path.join(distPath, "../"); // path/to/create-t3-app
```

when PKG_ROOT is accurately pointing to the package root again, the template folder can be found no matter what directory the app is scaffolded from. 
![CleanShot 2022-06-28 at 12 16 04](https://user-images.githubusercontent.com/51714798/176155159-17353cf3-8044-4861-a894-e1bbc53b7e0f.png)
