### PR TITLE
feat: add main as initial branch

### DIFF
--- a/src/helpers/initGit.ts
+++ b/src/helpers/initGit.ts
@@ -10,7 +10,7 @@ export const initializeGit = async (projectDir: string) => {
   logger.info("Initializing Git...");
   const spinner = ora("Creating a new git repo...\n").start();
   try {
-    await execa("git init", { cwd: projectDir });
+    await execa("git init --initial-branch=main", { cwd: projectDir });
     spinner.succeed(
       `${chalk.green("Successfully initialized")} ${chalk.green.bold("git")}\n`,
     );


### PR DESCRIPTION
Hello there,

When you run this tool it may initialize the repository with "master" as the principal branch. 

Is it ok if we specify "main"? Should we ask the user for the default branch name?

docs: https://git-scm.com/docs/git-init

Cheers,