### PR TITLE
fix: fix broken link on nextauth.js page

### DIFF
--- a/www/src/pages/en/usage/next-auth.md
+++ b/www/src/pages/en/usage/next-auth.md
@@ -164,7 +164,7 @@ Usage of NextAuth.js with Next.js middleware [requires the use of the JWT sessio
 - Under Client Secret, click "Reset Secret" and copy that string to `DISCORD_CLIENT_SECRET` in `.env`. Be careful as you won't be able to see this secret again, and resetting it will cause the existing one to expire.
 - Click "Add Redirect" and paste in `<app url>/api/auth/callback/discord` (example for local development: <code class="break-all">http://localhost:3000/api/auth/callback/discord</code>)
 - Save your changes
-- It is possible, but not recommended, to use the same Discord Application for both development and production. You could also consider [Mocking the Provider](https://github.com/trpc/trpc/blob/next/examples/next-prisma-starter-websockets/src/pages/api/auth/%5B...nextauth%5D.ts) during development.
+- It is possible, but not recommended, to use the same Discord Application for both development and production. You could also consider [Mocking the Provider](https://github.com/trpc/trpc/blob/main/examples/next-prisma-websockets-starter/src/pages/api/auth/%5B...nextauth%5D.ts) during development.
 
 ## Useful Resources
 


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] I performed a functional test on my final commit

---

## Changelog

Currently docs have broken link due to example dir change it's name.
See - https://github.com/trpc/trpc/commit/8a4b15e48bce87a255a63db26b6266fc5562b913.
I'm unsure how to functional test such change.

---
