### PR TITLE
feat(cli): add 'no src directory' option

### DIFF
--- a/.changeset/new-garlics-hammer.md
+++ b/.changeset/new-garlics-hammer.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": minor
+---
+
+add 'no src directory' option during project creation on the cli

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -20,6 +20,7 @@ interface CliFlags {
   noInstall: boolean;
   default: boolean;
   importAlias: string;
+  srcDir: boolean;
 
   /** @internal Used in CI. */
   CI: boolean;
@@ -52,6 +53,7 @@ const defaultOptions: CliResults = {
   flags: {
     noGit: false,
     noInstall: false,
+    srcDir: false,
     default: false,
     CI: false,
     tailwind: false,
@@ -89,6 +91,11 @@ export const runCli = async (): Promise<CliResults> => {
     .option(
       "-y, --default",
       "Bypass the CLI and use all default options to bootstrap a new t3-app",
+      false
+    )
+    .option(
+      "--srcDir",
+      "Explicitly tell the CLI to create a 'src' directory in the project",
       false
     )
     /** START CI-FLAGS */
@@ -253,6 +260,11 @@ export const runCli = async (): Promise<CliResults> => {
             message: "Will you be using Tailwind CSS for styling?",
           });
         },
+        srcDir: () => {
+          return p.confirm({
+            message: "Would you like to use 'src' directory?",
+          });
+        },
         trpc: () => {
           return p.confirm({
             message: "Would you like to use tRPC?",
@@ -350,6 +362,7 @@ export const runCli = async (): Promise<CliResults> => {
       flags: {
         ...cliResults.flags,
         appRouter: project.appRouter ?? cliResults.flags.appRouter,
+        srcDir: project.srcDir ?? cliResults.flags.srcDir,
         noGit: !project.git || cliResults.flags.noGit,
         noInstall: !project.install || cliResults.flags.noInstall,
         importAlias: project.importAlias ?? cliResults.flags.importAlias,

--- a/cli/src/helpers/moveProjectSrc.ts
+++ b/cli/src/helpers/moveProjectSrc.ts
@@ -1,0 +1,56 @@
+import path from "path";
+import fs from "fs-extra";
+
+import { type InstallerOptions } from "~/installers/index.js";
+
+type MoveProjectSrcProps = Required<
+  Pick<InstallerOptions, "packages" | "projectDir" | "appRouter">
+>;
+
+export const moveProjectSrc = async ({
+  projectDir,
+  packages,
+}: MoveProjectSrcProps) => {
+  const srcDir = path.join(projectDir, "src");
+
+  const usingTw = packages.tailwind.inUse;
+  const usingDrizzle = packages.drizzle.inUse;
+
+  if (usingDrizzle) {
+    const drizzleConfigFile = path.join(projectDir, "drizzle.config.ts");
+    fs.writeFileSync(
+      drizzleConfigFile,
+      fs
+        .readFileSync(drizzleConfigFile, "utf8")
+        .replace("./src/server/db/schema.ts", "./server/db/schema.ts")
+    );
+  }
+
+  if (usingTw) {
+    const tailwindConfigFile = path.join(projectDir, "tailwind.config.ts");
+    fs.writeFileSync(
+      tailwindConfigFile,
+      fs
+        .readFileSync(tailwindConfigFile, "utf8")
+        .replace("./src/**/*.tsx", "./**/*.tsx")
+    );
+  }
+
+  const tsconfigFile = path.join(projectDir, "tsconfig.json");
+  const nextconfigFile = path.join(projectDir, "next.config.js");
+  fs.writeFileSync(
+    tsconfigFile,
+    fs.readFileSync(tsconfigFile, "utf8").replace("./src/*", "./*")
+  );
+  fs.writeFileSync(
+    nextconfigFile,
+    fs.readFileSync(nextconfigFile, "utf8").replace("./src/env.js", "./env.js")
+  );
+
+  await fs.ensureDir(srcDir);
+
+  await fs.copy(srcDir, projectDir);
+
+  await fs.emptyDir(srcDir);
+  await fs.rmdir(srcDir);
+};

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -15,6 +15,7 @@ import { logger } from "~/utils/logger.js";
 import { parseNameAndPath } from "~/utils/parseNameAndPath.js";
 import { renderTitle } from "~/utils/renderTitle.js";
 import { installDependencies } from "./helpers/installDependencies.js";
+import { moveProjectSrc } from "./helpers/moveProjectSrc.js";
 import { getVersion } from "./utils/getT3Version.js";
 import {
   getNpmVersion,
@@ -36,7 +37,7 @@ const main = async () => {
   const {
     appName,
     packages,
-    flags: { noGit, noInstall, importAlias, appRouter },
+    flags: { noGit, noInstall, importAlias, appRouter, srcDir },
     databaseProvider,
   } = await runCli();
 
@@ -73,6 +74,10 @@ const main = async () => {
   fs.writeJSONSync(path.join(projectDir, "package.json"), pkgJson, {
     spaces: 2,
   });
+
+  if (!srcDir) {
+    await moveProjectSrc({ projectDir, packages: usePackages, appRouter });
+  }
 
   // update import alias in any generated files if not using the default
   if (importAlias !== "~/") {


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

- CLI option: `Would you like to use 'src' directory? yes/no`
- If yes, create the project with the `src` directory (current and default option at this moment) 
- If not, create the project without the `src` directory (I always do it manually 😭😭)

---

## Screenshots
<img width="584" alt="Screenshot 2024-07-07 at 11 17 14 PM" src="https://github.com/t3-oss/create-t3-app/assets/92900301/afccb0ab-b6b6-4942-8cf5-bc5e2007b57f">

💯
