### PR TITLE
docs: correct spelling of TYPE SAFETY

### DIFF
--- a/www/src/pages/en/introduction.mdx
+++ b/www/src/pages/en/introduction.mdx
@@ -10,7 +10,7 @@ import { IntroductionTab } from "../../components/docs/introductionTab";
 <IntroductionTab client:load />
 ## The T3 Stack
 
-The _"T3 Stack"_ is a web development stack made by [Theo](https://twitter.com/t3dotgg) focused on simplicity, modularity, and full-stack typesafety.
+The _"T3 Stack"_ is a web development stack made by [Theo](https://twitter.com/t3dotgg) focused on simplicity, modularity, and full-stack type safety.
 
 The core pieces are [**Next.js**](https://nextjs.org/) and [**TypeScript**](https://typescriptlang.org/). [**Tailwind CSS**](https://tailwindcss.com/) is almost always included. If you're doing anything resembling backend, [**tRPC**](https://trpc.io/), [**Prisma**](https://prisma.io/), and [**NextAuth.js**](https://next-auth.js.org/) are great additions too.
 


### PR DESCRIPTION
docs: correct spelling of TYPE SAFETY

Doesn't close an issue since I could not create an issue that was neither a bug nor a feature.

## ✅ Checklist

- [✅] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [✅] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [✅] I performed a functional test on my final commit

---

## Changelog

_Fixed small grammar issue (typesafety is not a word)._

---

## Screenshots

_Not needed._

💯
