### PR TITLE
fix: remove --turbo flag from dev script, add separate dev:turbo script

### DIFF
--- a/cli/template/base/package.json
+++ b/cli/template/base/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbo",
+    "dev": "next dev",
+    "dev:turbo": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "preview": "next build && next start",


### PR DESCRIPTION
## Description
This PR addresses issue #2145 where the `--turbo` flag in the dev script causes styling issues with shadcn/ui and potentially other CSS frameworks.

## Changes
- Removed `--turbo` flag from the default `dev` script
- Added a separate `dev:turbo` script for users who want to use turbo mode
- This provides flexibility while avoiding compatibility issues

## Why this change?
The `--turbo` flag can cause compatibility issues with certain CSS frameworks like shadcn/ui, making debugging extremely difficult. By separating the turbo functionality into its own script, we:

1. Fix the default behavior to work with all CSS frameworks
2. Still provide turbo functionality for users who want it
3. Make the development experience more predictable

## Testing
- Verified the package.json template generates correctly
- Confirmed both `npm run dev` and `npm run dev:turbo` work as expected