### PR TITLE
fix: Fix search text overlapping with input box in DocSearch modal

### DIFF
--- a/www/src/styles/algolia/style.css
+++ b/www/src/styles/algolia/style.css
@@ -625,3 +625,8 @@ svg.DocSearch-Hit-Select-Icon {
     opacity: 1;
   }
 }
+
+/* Fix overlapping of Search text with input box */
+.DocSearch-VisuallyHiddenForAccessibility {
+  margin-right: 8px;
+}


### PR DESCRIPTION
Added margin-right to .DocSearch-VisuallyHiddenForAccessibility class to prevent the 'Search' label from overlapping with the search input box border.

Closes #2151 

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit
---

## Changelog

Fix search text overlapping with input box in DocSearch modal

Added margin-right to .DocSearch-VisuallyHiddenForAccessibility class
to prevent the "Search" label from overlapping with the search input
box border.

---

## Screenshots

<img width="1625" height="506" alt="image" src="https://github.com/user-attachments/assets/83bd1695-37d2-49a5-af81-de87c90b5dcb" />

💯
