### PR TITLE
fix(ui): update default value for GitHub stars count component

### DIFF
--- a/www/src/components/navigation/githubIcon.astro
+++ b/www/src/components/navigation/githubIcon.astro
@@ -2,7 +2,7 @@
 import { getIsRtlFromUrl, getLanguageFromURL } from "../../languages";
 import { fetchGithub } from "../../utils/fetchGithub";
 
-let githubStars = 25000;
+let githubStars = 28000;
 
 try {
   const fetchedStars = await fetchGithub(
@@ -13,7 +13,7 @@ try {
     },
   ).then((data) => data?.stargazers_count);
 
-  githubStars = fetchedStars ?? 25000;
+  githubStars = fetchedStars ?? 28000;
 } catch (e) {
   console.error("unable to fetch from github", e);
 }


### PR DESCRIPTION
## Changelog

Updated the default value for the GitHub stars count component from `25000` to `28000` . 

---

## Screenshots
before:
<img width="2544" height="1348" alt="before" src="https://github.com/user-attachments/assets/33cc1df3-4225-41f6-8c97-243346ce9032" />

after:
<img width="2544" height="1348" alt="after" src="https://github.com/user-attachments/assets/8aee3729-c074-4e50-a05d-c8a29ce4b231" />
