### PR TITLE
fix: lint and format generated files using stricter config

### DIFF
--- a/cli/template/extras/src/app/layout/with-trpc-tw.tsx
+++ b/cli/template/extras/src/app/layout/with-trpc-tw.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" className={`${geist.variable}`}>
+    <html lang="en" className={geist.variable}>
       <body>
         <TRPCReactProvider>{children}</TRPCReactProvider>
       </body>

--- a/cli/template/extras/src/app/layout/with-tw.tsx
+++ b/cli/template/extras/src/app/layout/with-tw.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
   children,
 }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en" className={`${geist.variable}`}>
+    <html lang="en" className={geist.variable}>
       <body>{children}</body>
     </html>
   );

--- a/cli/template/extras/src/server/api/trpc-app/base.ts
+++ b/cli/template/extras/src/server/api/trpc-app/base.ts
@@ -88,7 +88,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-app/with-auth-db.ts
+++ b/cli/template/extras/src/server/api/trpc-app/with-auth-db.ts
@@ -96,7 +96,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-app/with-auth.ts
+++ b/cli/template/extras/src/server/api/trpc-app/with-auth.ts
@@ -93,7 +93,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-app/with-better-auth-db.ts
+++ b/cli/template/extras/src/server/api/trpc-app/with-better-auth-db.ts
@@ -97,7 +97,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-app/with-better-auth.ts
+++ b/cli/template/extras/src/server/api/trpc-app/with-better-auth.ts
@@ -94,7 +94,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-app/with-db.ts
+++ b/cli/template/extras/src/server/api/trpc-app/with-db.ts
@@ -91,7 +91,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-pages/base.ts
+++ b/cli/template/extras/src/server/api/trpc-pages/base.ts
@@ -107,7 +107,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-pages/with-auth-db.ts
+++ b/cli/template/extras/src/server/api/trpc-pages/with-auth-db.ts
@@ -123,7 +123,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-pages/with-auth.ts
+++ b/cli/template/extras/src/server/api/trpc-pages/with-auth.ts
@@ -121,7 +121,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-pages/with-better-auth-db.ts
+++ b/cli/template/extras/src/server/api/trpc-pages/with-better-auth-db.ts
@@ -131,7 +131,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-pages/with-better-auth.ts
+++ b/cli/template/extras/src/server/api/trpc-pages/with-better-auth.ts
@@ -129,7 +129,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/server/api/trpc-pages/with-db.ts
+++ b/cli/template/extras/src/server/api/trpc-pages/with-db.ts
@@ -110,7 +110,7 @@ const timingMiddleware = t.middleware(async ({ next, path }) => {
   const result = await next();
 
   const end = Date.now();
-  console.log(`[TRPC] ${path} took ${end - start}ms to execute`);
+  console.log(`[TRPC] ${path} took ${String(end - start)}ms to execute`);
 
   return result;
 });

--- a/cli/template/extras/src/styles/globals.css
+++ b/cli/template/extras/src/styles/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @theme {
-  --font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif,
+  --font-sans:
+    var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif,
     "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }

--- a/cli/template/extras/src/trpc/react.tsx
+++ b/cli/template/extras/src/trpc/react.tsx
@@ -74,5 +74,5 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 function getBaseUrl() {
   if (typeof window !== "undefined") return window.location.origin;
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`;
-  return `http://localhost:${process.env.PORT ?? 3000}`;
+  return `http://localhost:${process.env.PORT?.toString() ?? 3000}`;
 }

--- a/cli/template/extras/src/utils/api.ts
+++ b/cli/template/extras/src/utils/api.ts
@@ -14,7 +14,7 @@ import { type AppRouter } from "~/server/api/root";
 const getBaseUrl = () => {
   if (typeof window !== "undefined") return ""; // browser should use relative url
   if (process.env.VERCEL_URL) return `https://${process.env.VERCEL_URL}`; // SSR should use vercel url
-  return `http://localhost:${process.env.PORT ?? 3000}`; // dev SSR should use localhost
+  return `http://localhost:${process.env.PORT?.toString() ?? 3000}`; // dev SSR should use localhost
 };
 
 /** A set of type-safe react-query hooks for your tRPC API. */


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Switching to typescript-eslint `strictTypeChecked` config in a generated app reveals a handful of simple lint errors. This PR fixes those issues. Additionally, the generated Prettier write script omits CSS files, and the generated CSS is missing a single newline, which is also fixed in this PR. 

- Remove unnecessary template literal usage (@typescript-eslint/no-unnecessary-template-expression)
- Cast numbers to strings in console.log (@typescript-eslint/restrict-template-expressions)
- Format globals.css using Prettier