### PR TITLE
fix(a11y): Add aria-label to clipboard copy button

### DIFF
--- a/www/src/components/landingPage/ClipboardSelect.tsx
+++ b/www/src/components/landingPage/ClipboardSelect.tsx
@@ -42,8 +42,9 @@ export default function ClipboardSelect() {
     <div className="flex items-center gap-2">
       <Menu as="div">
         <div className="relative">
-          <Menu.Button className="relative flex cursor-pointer items-center justify-center rounded-lg border bg-t3-purple-200/50 p-2 text-left focus:outline-none hover:bg-t3-purple-200/75 sm:text-sm dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50">
+          <Menu.Button aria-label="Copy to clipboard" className="relative flex cursor-pointer items-center justify-center rounded-lg border bg-t3-purple-200/50 p-2 text-left focus:outline-none hover:bg-t3-purple-200/75 sm:text-sm dark:border-t3-purple-200/20 dark:bg-t3-purple-200/10 dark:hover:border-t3-purple-200/50">
             <svg
+              aria-hidden="true"
               className={`h-[1em] w-[1em] ${coolDown && "hidden"}`}
               xmlns="http://www.w3.org/2000/svg"
               width="24"


### PR DESCRIPTION
Closes #2185

## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Added `aria-label="Copy to clipboard"` to the clipboard copy button and marked the decorative SVG icon as `aria-hidden="true"` to fix accessibility violation 2. This ensures screen reader users can properly identify and interact with the copy button.

---

## Screenshots

**Fix Before:**
IBM Equal Access Accessibility Checker showing violation 2 - "/document[1] /main[1] /button[1]"
```
Form control element <button> has no associated label
The SVG element has no accessible name
```

<img width="2560" height="739" alt="image" src="https://github.com/user-attachments/assets/b7fa550e-c8f0-4d1f-ac5c-8142da497997" />

**Fix After:**
Accessibility violation resolved - button now has proper accessible label. Have resolved 2 (8-6) violations.

<img width="2560" height="799" alt="image" src="https://github.com/user-attachments/assets/398258ea-bad2-499d-b404-5e7c8075557c" />

💯
