### PR TITLE
fix(deps): bump drizzle-kit to ^0.31.8 to resolve better-auth conflict

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -79,7 +79,7 @@
     "@types/gradient-string": "^1.1.6",
     "@types/node": "^24.10.1",
     "better-auth": "^1.3",
-    "drizzle-kit": "^0.30.5",
+    "drizzle-kit": "^0.31.8",
     "drizzle-orm": "^0.41.0",
     "mysql2": "^3.11.0",
     "next": "^15.5.9",


### PR DESCRIPTION
fix(deps): bump drizzle-kit to ^0.31.8 to resolve better-auth conflict

## ✅ Checklist

- [✅] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [✅] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [✅] I performed a functional test on my final commit

---

## Changelog

- Updated `drizzle-kit` dependency in the Drizzle template to `^0.31.8`.
- Resolves an `ERRESOLVE` npm error during the `create-t3-app` installation flow where `better-auth@1.3` required a higher peer version of `drizzle-kit` than the scaffold currently provided.

---