### PR TITLE
fix: correct Better Auth + Drizzle + PostgreSQL template prefix and dependency versions

### DIFF
--- a/.changeset/fix-better-auth-drizzle.md
+++ b/.changeset/fix-better-auth-drizzle.md
@@ -1,0 +1,5 @@
+---
+'create-t3-app': patch
+---
+
+Fix Better Auth + Drizzle + PostgreSQL template: correct table prefix and dependency versions

--- a/cli/src/installers/dependencyVersionMap.ts
+++ b/cli/src/installers/dependencyVersionMap.ts
@@ -17,7 +17,7 @@ export const dependencyVersionMap = {
   "@prisma/adapter-planetscale": "^6.6.0",
 
   // Drizzle
-  "drizzle-kit": "^0.30.5",
+  "drizzle-kit": "^0.31.4",
   "drizzle-orm": "^0.41.0",
   mysql2: "^3.11.0",
   "@planetscale/database": "^1.19.0",

--- a/cli/template/extras/src/server/db/schema-drizzle/with-better-auth-postgres.ts
+++ b/cli/template/extras/src/server/db/schema-drizzle/with-better-auth-postgres.ts
@@ -8,7 +8,7 @@ import {
   timestamp,
 } from "drizzle-orm/pg-core";
 
-export const createTable = pgTableCreator((name) => `pg-drizzle_${name}`);
+export const createTable = pgTableCreator((name) => `project1_${name}`);
 
 export const posts = createTable(
   "post",


### PR DESCRIPTION
## Summary
This PR fixes two bugs in the Better Auth + Drizzle + PostgreSQL template:

### Issue #2184: Table prefix mismatch
- Changed hardcoded `pg-drizzle_${name}` prefix to `project1_${name}` in `with-better-auth-postgres.ts`
- This matches the pattern used by other schema templates (e.g., `base-postgres.ts`, `with-auth-postgres.ts`)
- The `project1_` prefix is correctly replaced by the installer with the actual project name

### Issue #2182: Dependency version conflict
- Updated `drizzle-kit` from `^0.30.5` to `^0.31.4` in `dependencyVersionMap.ts`
- This resolves the peer dependency conflict with `better-auth@1.4.10` which requires `drizzle-kit>=0.31.4`

## Changes
- `cli/template/extras/src/server/db/schema-drizzle/with-better-auth-postgres.ts`: Fixed table prefix
- `cli/src/installers/dependencyVersionMap.ts`: Updated drizzle-kit version constraint

## Testing
- Verified that other schema templates use `project1_${name}` prefix pattern
- Confirmed version bump aligns with better-auth requirements

## Disclosure

This PR was authored with the assistance of Claude (LLM) to help understand the codebase and structure the implementation and description.