### PR TITLE
fix(cli): handle boolean importAlias when --import-alias has no value

### DIFF
--- a/.changeset/fix-import-alias-crash.md
+++ b/.changeset/fix-import-alias-crash.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+fix(cli): handle boolean importAlias when --import-alias is used without a value in CI mode

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -200,6 +200,12 @@ export const runCli = async (): Promise<CliResults> => {
 
   cliResults.flags = program.opts();
 
+  // When --import-alias is passed without a value, Commander sets it to true (boolean).
+  // Fall back to the default alias in that case.
+  if (typeof cliResults.flags.importAlias !== "string") {
+    cliResults.flags.importAlias = defaultOptions.flags.importAlias;
+  }
+
   /** @internal Used for CI E2E tests. */
   if (cliResults.flags.CI) {
     cliResults.packages = [];


### PR DESCRIPTION
Fixes #2215

When `--import-alias` (or `-i`) is used in CI mode without providing a value, Commander parses the option as `true` (boolean) instead of a string. This causes a `TypeError: i.replace is not a function` crash in `setImportAlias.ts` because `.replace()` is called on a boolean.

The fix adds a type check after parsing CLI options - if `importAlias` is not a string, it falls back to the default value (`"~/"`).

**Reproduction:**
```bash
npx create-t3-app@latest my-app --CI --import-alias
# TypeError: i.replace is not a function
```

**After fix:**
```bash
npx create-t3-app@latest my-app --CI --import-alias
# Uses default "~/" alias
```