### PR TITLE
feat!: update @clack/prompts dependency

### DIFF
--- a/.changeset/rude-books-prove.md
+++ b/.changeset/rude-books-prove.md
@@ -1,0 +1,7 @@
+---
+"create-t3-app": major
+---
+
+Updates `@clack/prompts` dependency to v1.4
+
+Drops support for Node 18

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,7 @@
     "package.json"
   ],
   "engines": {
-    "node": ">=18.17.0"
+    "node": ">=20.12.0"
   },
   "scripts": {
     "typecheck": "tsc",
@@ -50,9 +50,7 @@
     "pub:release": "pnpm build && npm publish"
   },
   "dependencies": {
-    "@clack/core": "^0.3.4",
-    "@clack/prompts": "^0.6.3",
-    "@ianvs/prettier-plugin-sort-imports": "^4.2.1",
+    "@clack/prompts": "^1.4.0",
     "chalk": "5.2.0",
     "commander": "^10.0.1",
     "execa": "^7.2.0",
@@ -64,6 +62,7 @@
   "devDependencies": {
     "@auth/drizzle-adapter": "^1.1.0",
     "@auth/prisma-adapter": "^1.6.0",
+    "@ianvs/prettier-plugin-sort-imports": "^4.2.1",
     "@libsql/client": "^0.14.0",
     "@planetscale/database": "^1.19.0",
     "@prisma/adapter-planetscale": "^6.6.0",

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -280,7 +280,7 @@ export const runCli = async (): Promise<CliResults> => {
             initialValue: "typescript",
           });
         },
-        _: ({ results }) =>
+        _: async ({ results }) =>
           results.language === "javascript"
             ? p.note(chalk.redBright("Wrong answer, using TypeScript instead"))
             : undefined,

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -284,6 +284,7 @@ export const runCli = async (): Promise<CliResults> => {
           if (results.language === "javascript") {
             p.note(chalk.redBright("Wrong answer, using TypeScript instead"));
           }
+          return;
         },
         styling: () => {
           return p.confirm({

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -284,7 +284,7 @@ export const runCli = async (): Promise<CliResults> => {
           if (results.language === "javascript") {
             p.note(chalk.redBright("Wrong answer, using TypeScript instead"));
           }
-          return;
+          return undefined;
         },
         styling: () => {
           return p.confirm({

--- a/cli/src/cli/index.ts
+++ b/cli/src/cli/index.ts
@@ -280,10 +280,11 @@ export const runCli = async (): Promise<CliResults> => {
             initialValue: "typescript",
           });
         },
-        _: async ({ results }) =>
-          results.language === "javascript"
-            ? p.note(chalk.redBright("Wrong answer, using TypeScript instead"))
-            : undefined,
+        _: ({ results }) => {
+          if (results.language === "javascript") {
+            p.note(chalk.redBright("Wrong answer, using TypeScript instead"));
+          }
+        },
         styling: () => {
           return p.confirm({
             message: "Will you be using Tailwind CSS for styling?",

--- a/cli/src/utils/validateAppName.ts
+++ b/cli/src/utils/validateAppName.ts
@@ -4,7 +4,11 @@ const validationRegExp =
   /^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
 
 //Validate a string against allowed package.json names
-export const validateAppName = (rawInput: string) => {
+export const validateAppName = (rawInput?: string) => {
+  if (!rawInput) {
+    return;
+  }
+
   const input = removeTrailingSlash(rawInput);
   const paths = input.split("/");
 

--- a/cli/src/utils/validateImportAlias.ts
+++ b/cli/src/utils/validateImportAlias.ts
@@ -1,4 +1,7 @@
-export const validateImportAlias = (input: string) => {
+export const validateImportAlias = (input?: string) => {
+  if (!input) {
+    return;
+  }
   if (input.startsWith(".") || input.startsWith("/")) {
     return "Import alias can't start with '.' or '/'";
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,15 +62,9 @@ importers:
 
   cli:
     dependencies:
-      '@clack/core':
-        specifier: ^0.3.4
-        version: 0.3.4
       '@clack/prompts':
-        specifier: ^0.6.3
-        version: 0.6.3
-      '@ianvs/prettier-plugin-sort-imports':
-        specifier: ^4.2.1
-        version: 4.4.1(prettier@3.5.3)
+        specifier: ^1.4.0
+        version: 1.4.0
       chalk:
         specifier: 5.2.0
         version: 5.2.0
@@ -99,6 +93,9 @@ importers:
       '@auth/prisma-adapter':
         specifier: ^1.6.0
         version: 1.6.0(@prisma/client@6.6.0(prisma@6.6.0(typescript@5.8.2))(typescript@5.8.2))
+      '@ianvs/prettier-plugin-sort-imports':
+        specifier: ^4.2.1
+        version: 4.4.1(prettier@3.5.3)
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0
@@ -195,37 +192,6 @@ importers:
       zod:
         specifier: ^3.24.2
         version: 3.24.2
-
-  cli/template/base:
-    dependencies:
-      '@t3-oss/env-nextjs':
-        specifier: ^0.12.0
-        version: 0.12.0(typescript@5.9.3)(zod@3.25.76)
-      next:
-        specifier: ^15.5.9
-        version: 15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react:
-        specifier: ^19.2.3
-        version: 19.2.3
-      react-dom:
-        specifier: ^19.2.3
-        version: 19.2.3(react@19.2.3)
-      zod:
-        specifier: ^3.24.2
-        version: 3.25.76
-    devDependencies:
-      '@types/node':
-        specifier: ^24.10.1
-        version: 24.10.3
-      '@types/react':
-        specifier: ~19.1.0
-        version: 19.1.17
-      '@types/react-dom':
-        specifier: ~19.1.0
-        version: 19.1.11(@types/react@19.1.17)
-      typescript:
-        specifier: ^5.8.2
-        version: 5.9.3
 
   www:
     dependencies:
@@ -696,13 +662,13 @@ packages:
   '@changesets/write@0.3.1':
     resolution: {integrity: sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==}
 
-  '@clack/core@0.3.4':
-    resolution: {integrity: sha512-H4hxZDXgHtWTwV3RAVenqcC4VbJZNegbBjlPvzOzCouXtS2y3sDvlO3IsbrPNWuLWPPlYVYPghQdSF64683Ldw==}
+  '@clack/core@1.3.1':
+    resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
+    engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@0.6.3':
-    resolution: {integrity: sha512-AM+kFmAHawpUQv2q9+mcB6jLKxXGjgu/r2EQjEwujgpCdzrST6BJqYw00GRn56/L/Izw5U7ImoLmy00X/r80Pw==}
-    bundledDependencies:
-      - is-unicode-supported
+  '@clack/prompts@1.4.0':
+    resolution: {integrity: sha512-S0My7XPGIgpRWMDG8uRqalbgT+a6FmCUdOW+HaIOVVpUPHOb7RrpvjTjiODadKp06fsrVDJZlIzc6yCTp4AnxA==}
+    engines: {node: '>= 20.12.0'}
 
   '@docsearch/css@3.9.0':
     resolution: {integrity: sha512-cQbnVbq0rrBwNAKegIac/t6a8nWoUAn8frnkLFW6YARaRmAQr5/Eoe6Ln2fqkUCZ40KpdrKbpSAmgrkviOxuWA==}
@@ -2293,9 +2259,6 @@ packages:
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
-  '@types/node@24.10.3':
-    resolution: {integrity: sha512-gqkrWUsS8hcm0r44yn7/xZeV1ERva/nLgrLxFRUGb7aoNMIJfZJ3AC261zDQuOAKC7MiXai1WCpYc48jAHoShQ==}
-
   '@types/normalize-package-data@2.4.1':
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
 
@@ -3506,8 +3469,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
@@ -3669,6 +3641,7 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@11.12.0:
@@ -5741,6 +5714,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -5945,11 +5919,6 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
 
@@ -6096,6 +6065,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -6453,9 +6423,6 @@ packages:
 
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -7065,15 +7032,16 @@ snapshots:
       human-id: 1.0.2
       prettier: 2.8.8
 
-  '@clack/core@0.3.4':
+  '@clack/core@1.3.1':
     dependencies:
-      picocolors: 1.1.1
+      fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
-  '@clack/prompts@0.6.3':
+  '@clack/prompts@1.4.0':
     dependencies:
-      '@clack/core': 0.3.4
-      picocolors: 1.1.1
+      '@clack/core': 1.3.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
       sisteransi: 1.0.5
 
   '@docsearch/css@3.9.0': {}
@@ -8189,24 +8157,12 @@ snapshots:
       typescript: 5.8.2
       zod: 3.24.2
 
-  '@t3-oss/env-core@0.12.0(typescript@5.9.3)(zod@3.25.76)':
-    optionalDependencies:
-      typescript: 5.9.3
-      zod: 3.25.76
-
   '@t3-oss/env-nextjs@0.12.0(typescript@5.8.2)(zod@3.24.2)':
     dependencies:
       '@t3-oss/env-core': 0.12.0(typescript@5.8.2)(zod@3.24.2)
     optionalDependencies:
       typescript: 5.8.2
       zod: 3.24.2
-
-  '@t3-oss/env-nextjs@0.12.0(typescript@5.9.3)(zod@3.25.76)':
-    dependencies:
-      '@t3-oss/env-core': 0.12.0(typescript@5.9.3)(zod@3.25.76)
-    optionalDependencies:
-      typescript: 5.9.3
-      zod: 3.25.76
 
   '@tailwindcss/node@4.0.15':
     dependencies:
@@ -8403,10 +8359,6 @@ snapshots:
   '@types/node@17.0.45': {}
 
   '@types/node@24.10.1':
-    dependencies:
-      undici-types: 7.16.0
-
-  '@types/node@24.10.3':
     dependencies:
       undici-types: 7.16.0
 
@@ -9873,7 +9825,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.0.6: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.15.0:
     dependencies:
@@ -11322,29 +11284,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.9(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
-    dependencies:
-      '@next/env': 15.5.9
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001760
-      postcss: 8.4.31
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(react@19.2.3)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.7
-      '@next/swc-darwin-x64': 15.5.7
-      '@next/swc-linux-arm64-gnu': 15.5.7
-      '@next/swc-linux-arm64-musl': 15.5.7
-      '@next/swc-linux-x64-gnu': 15.5.7
-      '@next/swc-linux-x64-musl': 15.5.7
-      '@next/swc-win32-arm64-msvc': 15.5.7
-      '@next/swc-win32-x64-msvc': 15.5.7
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -12546,11 +12485,6 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.26.10
 
-  styled-jsx@5.1.6(react@19.2.3):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.3
-
   sucrase@3.35.0:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
@@ -12821,8 +12755,6 @@ snapshots:
       - supports-color
 
   typescript@5.8.2: {}
-
-  typescript@5.9.3: {}
 
   ufo@1.5.4: {}
 
@@ -13301,7 +13233,5 @@ snapshots:
       zod: 3.24.2
 
   zod@3.24.2: {}
-
-  zod@3.25.76: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## ✅ Checklist

- [x] I have followed every step in the [contributing guide](https://github.com/t3-oss/create-t3-app/blob/main/CONTRIBUTING.md) (updated 2022-10-06).
- [x] The PR title follows the convention we established [conventional-commit](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I performed a functional test on my final commit

---

## Changelog

Updates `@clack/prompts` dependency to the latest version (v1.4)

Also updates minimum Node.js version to 20.12.0, the minimum supported  by `@clack/prompts` v1.4

Also moved `@ianvs/prettier-plugin-sort-imports` to dev dependencies as it does not seem to be used by the cli

---

## Screenshots

N/A
