### PR TITLE
docs: clarify tRPC frontend entrypoints

### DIFF
--- a/www/src/pages/en/usage/trpc.md
+++ b/www/src/pages/en/usage/trpc.md
@@ -155,9 +155,9 @@ Here we [merge](https://trpc.io/docs/v11/server/merging-routers) all the sub-rou
 
 ### 📄 `utils/api.ts`
 
-This is the frontend entry point for tRPC. This is where you'll import the router's **type definition** and create your tRPC client along with the react-query hooks. Since we enabled `superjson` as our data transformer on the backend, we need to enable it on the frontend as well. This is because the serialized data from the backend is deserialized on the frontend.
+In the Pages Router setup, this is the frontend entry point for tRPC. This is where you'll import the router's **type definition** and create your tRPC client along with the react-query hooks. Since we enabled `superjson` as our data transformer on the backend, we need to enable it on the frontend as well. This is because the serialized data from the backend is deserialized on the frontend.
 
-You'll define your tRPC [links](https://trpc.io/docs/v11/client/links) here, which determines the request flow from the client to the server. We use the "default" [`httpBatchLink`](https://trpc.io/docs/v11/client/links/httpBatchLink) which enables [request batching](https://cloud.google.com/compute/docs/api/how-tos/batch), as well as a [`loggerLink`](https://trpc.io/docs/v10/links/loggerLink) which outputs useful request logs during development.
+If you're using the App Router, the equivalent frontend entry point lives in `src/trpc/react.tsx` instead. The underlying idea is the same: define your tRPC [links](https://trpc.io/docs/v11/client/links), which determines the request flow from the client to the server. We use the "default" [`httpBatchLink`](https://trpc.io/docs/v11/client/links/httpBatchLink) which enables [request batching](https://cloud.google.com/compute/docs/api/how-tos/batch), as well as a [`loggerLink`](https://trpc.io/docs/v10/links/loggerLink) which outputs useful request logs during development.
 
 Lastly, we export a [helper type](https://trpc.io/docs/client/vanilla/infer-types) which you can use to infer your types on the frontend.
 


### PR DESCRIPTION
## Summary
Update the tRPC usage docs to better reflect the current frontend entrypoints.

## Why
The docs still lean on an older utils/api.ts framing, which can be confusing when comparing Pages Router and App Router setup.

## What changed
- Clarified that utils/api.ts is the Pages Router entry point
- Pointed App Router readers to src/trpc/react.tsx
- Kept the rest of the tRPC walkthrough intact

## Verification
- Cross-checked the docs against the current scaffold structure