### PR TITLE
feat: detect nub package manager

### DIFF
--- a/.changeset/tame-donkeys-wave.md
+++ b/.changeset/tame-donkeys-wave.md
@@ -1,0 +1,5 @@
+---
+"create-t3-app": patch
+---
+
+Detect the nub package manager

--- a/cli/src/helpers/installDependencies.ts
+++ b/cli/src/helpers/installDependencies.ts
@@ -69,6 +69,19 @@ const runInstallCommand = async (
     // When using bun, the stdout stream is ignored and the spinner is shown
     case "bun":
       return execWithSpinner(projectDir, pkgManager, { stdout: "ignore" });
+    // nub is pnpm-CLI-compatible, so mirror the pnpm progress handling
+    case "nub":
+      return execWithSpinner(projectDir, pkgManager, {
+        onDataHandle: (spinner) => (data) => {
+          const text = data.toString();
+
+          if (text.includes("Progress")) {
+            spinner.text = text.includes("|")
+              ? (text.split(" | ")[1] ?? "")
+              : text;
+          }
+        },
+      });
   }
 };
 

--- a/cli/src/helpers/logNextSteps.ts
+++ b/cli/src/helpers/logNextSteps.ts
@@ -40,7 +40,7 @@ export const logNextSteps = async ({
   }
 
   if (packages?.prisma.inUse || packages?.drizzle.inUse) {
-    if (["npm", "bun"].includes(pkgManager)) {
+    if (["npm", "bun", "nub"].includes(pkgManager)) {
       logger.info(`  ${pkgManager} run db:push`);
     } else {
       logger.info(`  ${pkgManager} db:push`);
@@ -53,7 +53,7 @@ export const logNextSteps = async ({
     );
   }
 
-  if (["npm", "bun"].includes(pkgManager)) {
+  if (["npm", "bun", "nub"].includes(pkgManager)) {
     logger.info(`  ${pkgManager} run dev`);
   } else {
     logger.info(`  ${pkgManager} dev`);

--- a/cli/src/utils/getUserPkgManager.ts
+++ b/cli/src/utils/getUserPkgManager.ts
@@ -1,4 +1,4 @@
-export type PackageManager = "npm" | "pnpm" | "yarn" | "bun";
+export type PackageManager = "npm" | "pnpm" | "yarn" | "bun" | "nub";
 
 export const getUserPkgManager: () => PackageManager = () => {
   // This environment variable is set by npm and yarn but pnpm seems less consistent
@@ -11,6 +11,8 @@ export const getUserPkgManager: () => PackageManager = () => {
       return "pnpm";
     } else if (userAgent.startsWith("bun")) {
       return "bun";
+    } else if (userAgent.startsWith("nub")) {
+      return "nub";
     } else {
       return "npm";
     }


### PR DESCRIPTION
When invoked through nub, create-t3-app defaults to npm. `getUserPkgManager` reads `npm_config_user_agent` and falls back to npm; [nub](https://nubjs.com) advertises `nub/<version>`, so it isn't matched.

nub is a Rust CLI with a pnpm-compatible command grammar, but — like npm — it has no implicit script shortcut, so scripts run via `nub run <script>`. This adds nub to the type and detection, and to the `["npm", "bun"]` groups in `logNextSteps` that emit the `run`-prefixed form, yielding `nub install` and `nub run dev`.
