### PR TITLE
fix(prettier): add .prettierignore to exclude generated Prisma client

### DIFF
--- a/.changeset/loud-frogs-jump.md
+++ b/.changeset/loud-frogs-jump.md
@@ -1,0 +1,20 @@
+---
+"create-t3-app": patch
+---
+
+Add .prettierignore to exclude generated Prisma client from formatting
+
+When scaffolding with Prisma + ESLint/Prettier, `prettier --write` and
+`prettier --check` would scan `generated/prisma/**` because the format
+scripts use a broad `**/*.{ts,tsx,js,jsx,mdx}` glob. Prettier does not
+read `.gitignore` by default, so the `/generated/` entry there offered
+no protection. This caused:
+
+- `prettier --write` reformatting generated Prisma client files
+- `prisma generate` rewriting them back to the original format
+- Persistent git diff churn on every install/format cycle
+
+Add a `.prettierignore` template that excludes `generated/` so Prettier
+skips generated artifacts deterministically, regardless of git state.
+
+Fixes #2217

--- a/cli/src/installers/eslint.ts
+++ b/cli/src/installers/eslint.ts
@@ -43,6 +43,12 @@ export const dynamicEslintInstaller: Installer = ({ projectDir, packages }) => {
 
   fs.copySync(prettierSrc, prettierDest);
 
+  // .prettierignore — prevents Prettier from formatting generated files
+  // (e.g. Prisma client under generated/prisma/) which cause persistent
+  // git diff churn. See https://github.com/t3-oss/create-t3-app/issues/2217
+  const prettierIgnoreSrc = path.join(extrasDir, "config/_prettierignore");
+  fs.copySync(prettierIgnoreSrc, path.join(projectDir, ".prettierignore"));
+
   // pnpm
   const pkgManager = getUserPkgManager();
   if (pkgManager === "pnpm") {

--- a/cli/template/extras/config/_prettierignore
+++ b/cli/template/extras/config/_prettierignore
@@ -1,0 +1,2 @@
+# Prisma generated client
+generated/


### PR DESCRIPTION
## Description

When scaffolding a T3 app with Prisma + ESLint/Prettier, the format scripts (`format:write`, `format:check`) use a broad `**/*.{ts,tsx,js,jsx,mdx}` glob that sweeps through `generated/prisma/**`. Prettier does **not** read `.gitignore` by default, so the existing `/generated/` entry in `.gitignore` offers no protection.

This causes a persistent churn cycle:
1. `prettier --write` reformats generated Prisma client files
2. `prisma generate` (runs on `postinstall`) rewrites them back to original format
3. Git shows noisy diffs in `generated/prisma/**` on every install/format

## Root Cause

The template has no `.prettierignore`. The `.gitignore` entry for `/generated/` is irrelevant to Prettier — it only reads `.prettierignore` or the file specified by `--ignore-path` (neither exists in the scaffold).

This is the Prettier counterpart to #2226 (Biome linting generated files), with the same underlying cause: generated artifacts are not excluded from the formatter/linter.

## Fix

**1. Add `.prettierignore` template** (`cli/template/extras/config/_prettierignore`)

```
# Prisma generated client
generated/
```

The `_` prefix follows the existing convention for dotfiles in the template (e.g. `_gitignore`, `_npmrc`) to ensure npm includes them in the package.

**2. Copy `.prettierignore` to the project from the ESLint installer**

The file is only relevant when ESLint/Prettier is selected (Biome users are unaffected — Biome has its own `files.includes` ignore mechanism, fixed in #2239). The copy is added to `dynamicEslintInstaller` alongside the existing Prettier config copy.

Fixes #2217

## Testing

- [x] `pnpm --filter create-t3-app typecheck` passes
- [x] `pnpm --filter create-t3-app build` passes
- [x] Changeset included (`patch`)
- [ ] Manual: scaffold with `pnpm create t3-app`, select Prisma + ESLint/Prettier, run `pnpm format:write`, verify `generated/` is not touched
